### PR TITLE
fix(deps): clear vitest critical and devalue high vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@sveltejs/kit": "2.57.1",
 		"@sveltejs/vite-plugin-svelte": "6.2.4",
 		"@tailwindcss/vite": "4.2.1",
-		"@vitest/coverage-v8": "3.2.4",
+		"@vitest/coverage-v8": "3.2.6",
 		"bits-ui": "2.16.2",
 		"clsx": "2.1.1",
 		"eslint": "9.39.3",
@@ -68,7 +68,7 @@
 		"typescript": "5.9.3",
 		"typescript-eslint": "8.56.1",
 		"vite": "6.4.2",
-		"vitest": "3.2.4",
+		"vitest": "3.2.6",
 		"wrangler": "4.69.0"
 	},
 	"pnpm": {
@@ -79,7 +79,7 @@
 		},
 		"overrides": {
 			"cookie": "1.1.1",
-			"devalue": "5.6.4",
+			"devalue": "5.8.1",
 			"flatted": "3.4.2",
 			"lodash-es": "4.18.1",
 			"picomatch": "2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   cookie: 1.1.1
-  devalue: 5.6.4
+  devalue: 5.8.1
   flatted: 3.4.2
   lodash-es: 4.18.1
   picomatch: 2.3.2
@@ -73,8 +73,8 @@ importers:
         specifier: 4.2.1
         version: 4.2.1(vite@6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))
+        specifier: 3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))
       bits-ui:
         specifier: 2.16.2
         version: 2.16.2(@internationalized/date@3.11.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.6)(vite@6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.6)(typescript@5.9.3)(vite@6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.6)
@@ -136,8 +136,8 @@ importers:
         specifier: 6.4.2
         version: 6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)
       vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)
+        specifier: 3.2.6
+        version: 3.2.6(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)
       wrangler:
         specifier: 4.69.0
         version: 4.69.0
@@ -1342,20 +1342,20 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@3.2.6':
+    resolution: {integrity: sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 3.2.6
+      vitest: 3.2.6
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -1365,20 +1365,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@xyflow/svelte@1.5.1':
     resolution: {integrity: sha512-PsurMZxEaTrAwt+PzQtzEkwZwJ9dSc92kusz1rNJTogU1ATxIwheznO2R+RCf2GNuyRuExeDn26WwwBTqkCIhg==}
@@ -1719,8 +1719,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  devalue@5.6.4:
-    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2848,16 +2848,16 @@ packages:
       vite:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3694,7 +3694,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 1.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -3935,7 +3935,7 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3950,49 +3950,49 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)
+      vitest: 3.2.6(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@3.2.6':
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.6(vite@6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@3.2.6':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@3.2.6':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 3.2.6
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@3.2.6':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
+  '@vitest/spy@3.2.6':
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@3.2.6':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 3.2.6
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -4317,7 +4317,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  devalue@5.6.4: {}
+  devalue@5.8.1: {}
 
   didyoumean@1.2.2: {}
 
@@ -5269,7 +5269,7 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
       esrap: 2.2.3
       is-reference: 3.0.3
@@ -5437,16 +5437,16 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2)
 
-  vitest@3.2.4(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2):
+  vitest@3.2.6(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@6.4.2(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0


### PR DESCRIPTION
## Summary

SCA audit of `workflow-metrics` surfaced two High/Critical findings with published fixes. Both are addressed with targeted minor-version bumps and a refreshed lockfile; no API/breaking changes.

- **Critical** `vitest` 3.2.4 → 3.2.6 (dev) — closes [GHSA-5xrq-8626-4rwp](https://github.com/advisories/GHSA-5xrq-8626-4rwp). Vitest UI server could allow arbitrary file read/execute when listening. Dev-only, no production runtime impact, but CI runs coverage in the same process. Bumped `vitest` and `@vitest/coverage-v8` in lockstep.
- **High** `devalue` 5.6.4 → 5.8.1 (transitive via `svelte`, pinned via `pnpm.overrides`) — closes [GHSA-77vg-94rm-hx3p](https://github.com/advisories/GHSA-77vg-94rm-hx3p). DoS via sparse array deserialization in Svelte's devalue serializer, reachable from Svelte server-rendered HTML on Cloudflare Pages.

Refs [TIM-6](https://multica/tim-6) / [TIM-7](https://multica/tim-7).

## Verification (pnpm 10.30.3, matches CI)

- `pnpm audit --audit-level=high` → **0 high, 0 critical**
- `pnpm test` → **148/148 pass** across 9 test files
- `pnpm lint` → clean
- `pnpm run check` → 0 errors (1 pre-existing warning in `DoraWorkflowDialog`, not introduced here)
- `pnpm run build` (with stub Supabase env) → Cloudflare adapter succeeded in ~15s

## Out of scope (tracked as follow-up)

17 moderate findings remain: `brace-expansion` (1.1.12, 2.0.2, 5.0.4), `yaml` (1.10.2, 2.8.2), `dompurify` 3.3.2 (4 advisories), `postcss` 8.5.6, `svelte` 5.53.6 (4 advisories, cleared at 5.55.7), `ws` 8.18.0/8.19.0, `@sveltejs/kit` 2.57.1. Most are dev-only transitive; the runtime ones (`svelte`, `dompurify`, `ws`) are next-patch bumps. Splitting into a separate PR to keep this diff auditable.

## Risk: pnpm 11 deprecation of `pnpm.overrides` in `package.json`

pnpm ≥11 silently ignores the `pnpm.overrides` block we used for `devalue`, which would re-introduce the HIGH. CI is currently pinned to pnpm 10.30.3 via `actions/setup`, so this is non-urgent but should land before that pin is lifted — move the overrides to `pnpm-workspace.yaml`. Will be tracked with the moderate follow-up.

## Stack note

Issue description mentioned Supabase Edge Functions / Deno, but the actual stack is SvelteKit on Cloudflare Pages with a Supabase JS client. The `supabase/` directory contains only SQL migrations, no `functions/`. Deno audit was not applicable.

🤖 Generated with [Multica DevSecOps](https://multica)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing framework and dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->