### PR TITLE
fix(deps): address TIM-44 moderate vulnerabilities from TIM-37 audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@supabase/supabase-js": "2.98.0",
 		"@xyflow/svelte": "1.5.1",
 		"ai": "6.0.105",
-		"dompurify": "3.3.2",
+		"dompurify": "^3.4.11",
 		"highlight.js": "11.11.1",
 		"layerchart": "1.0.13",
 		"marked": "17.0.3",
@@ -44,7 +44,7 @@
 	"devDependencies": {
 		"@eslint/js": "9.39.3",
 		"@sveltejs/adapter-cloudflare": "7.2.8",
-		"@sveltejs/kit": "2.57.1",
+		"@sveltejs/kit": "^2.60.1",
 		"@sveltejs/vite-plugin-svelte": "6.2.4",
 		"@tailwindcss/vite": "4.3.0",
 		"@vitest/coverage-v8": "3.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,16 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion: 5.0.6
   cookie: 1.1.1
   devalue: 5.8.1
   esbuild: 0.28.1
   flatted: 3.4.2
+  js-yaml: ^4.2.0
   lodash-es: 4.18.1
   picomatch: 2.3.2
+  postcss: ^8.5.10
+  postcss-load-config>yaml: 1.10.3
   undici: 7.28.0
   ws: 8.21.0
   zod: 4.3.6
@@ -41,8 +45,8 @@ importers:
         specifier: 6.0.105
         version: 6.0.105(zod@4.3.6)
       dompurify:
-        specifier: 3.3.2
-        version: 3.3.2
+        specifier: ^3.4.11
+        version: 3.4.11
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -64,10 +68,10 @@ importers:
         version: 9.39.3
       '@sveltejs/adapter-cloudflare':
         specifier: 7.2.8
-        version: 7.2.8(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(wrangler@4.69.0)
+        version: 7.2.8(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(wrangler@4.69.0)
       '@sveltejs/kit':
-        specifier: 2.57.1
-        version: 2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
+        specifier: ^2.60.1
+        version: 2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: 6.2.4
         version: 6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
@@ -79,7 +83,7 @@ importers:
         version: 3.2.6(vitest@3.2.6(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
       bits-ui:
         specifier: 2.16.2
-        version: 2.16.2(@internationalized/date@3.11.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
+        version: 2.16.2(@internationalized/date@3.11.0)(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -946,19 +950,14 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/acorn-typescript@1.0.9':
-    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
-    peerDependencies:
-      acorn: ^8.9.0
-
   '@sveltejs/adapter-cloudflare@7.2.8':
     resolution: {integrity: sha512-bIdhY/Fi4AQmqiBdQVKnafH1h9Gw+xbCvHyUu4EouC8rJOU02zwhi14k/FDhQ0mJF1iblIu3m8UNQ8GpGIvIOQ==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
       wrangler: ^4.0.0
 
-  '@sveltejs/kit@2.57.1':
-    resolution: {integrity: sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==}
+  '@sveltejs/kit@2.68.0':
+    resolution: {integrity: sha512-PdKiWsqinAoubVsSiRgVFkg3MHzGhQPnwQ8VxnGQKpZYijpapZ3UHHBje0GeByt2TvfjHPw+kxV+dNK2RIZg9g==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -1302,9 +1301,6 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1326,14 +1322,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1390,9 +1380,6 @@ packages:
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -1579,9 +1566,8 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  dompurify@3.3.2:
-    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
-    engines: {node: '>=20'}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1891,8 +1877,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2111,8 +2097,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2197,19 +2183,19 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: ^8.5.10
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: ^8.5.10
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
-      postcss: '>=8.0.9'
+      postcss: ^8.5.10
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -2222,9 +2208,9 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: ^8.5.10
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: 1.10.3
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -2239,19 +2225,19 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: ^8.5.10
 
   postcss-safe-parser@7.0.1:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: ^8.5.10
 
   postcss-scss@4.0.9:
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.4.29
+      postcss: ^8.5.10
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -2264,8 +2250,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2781,8 +2767,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
   yaml@2.9.0:
@@ -3003,7 +2989,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3441,21 +3427,17 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
-    dependencies:
-      acorn: 8.16.0
-
-  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(wrangler@4.69.0)':
+  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(wrangler@4.69.0)':
     dependencies:
       '@cloudflare/workers-types': 4.20260228.1
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
       worktop: 0.8.0-next.18
       wrangler: 4.69.0
 
-  '@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
       '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
@@ -3834,39 +3816,28 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   before-after-hook@4.0.0: {}
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@2.16.2(@internationalized/date@3.11.0)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1)):
+  bits-ui@2.16.2(@internationalized/date@3.11.0)(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1)):
     dependencies:
       '@floating-ui/core': 1.7.4
       '@floating-ui/dom': 1.7.5
       '@internationalized/date': 3.11.0
       esm-env: 1.2.2
-      runed: 0.35.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
+      runed: 0.35.1(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
       svelte: 5.56.1(@typescript-eslint/types@8.56.1)
-      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
       tabbable: 6.4.0
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
   blake3-wasm@2.1.5: {}
 
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3922,8 +3893,6 @@ snapshots:
   commander@4.1.1: {}
 
   commander@7.2.0: {}
-
-  concat-map@0.0.1: {}
 
   cookie@1.1.1: {}
 
@@ -4089,7 +4058,7 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  dompurify@3.3.2:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4147,9 +4116,9 @@ snapshots:
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
-      postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)
-      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+      postcss: 8.5.15
+      postcss-load-config: 3.1.4(postcss@8.5.15)
+      postcss-safe-parser: 7.0.1(postcss@8.5.15)
       semver: 7.7.4
       svelte-eslint-parser: 1.5.1(svelte@5.56.1(@typescript-eslint/types@8.56.1))
     optionalDependencies:
@@ -4416,7 +4385,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4599,15 +4568,15 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 5.0.6
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.6
 
   minipass@7.1.3: {}
 
@@ -4629,7 +4598,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
 
@@ -4689,45 +4658,45 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  postcss-import@15.1.0(postcss@8.5.6):
+  postcss-import@15.1.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.6):
+  postcss-js@4.1.0(postcss@8.5.15):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.15
 
-  postcss-load-config@3.1.4(postcss@8.5.6):
+  postcss-load-config@3.1.4(postcss@8.5.15):
     dependencies:
       lilconfig: 2.1.0
-      yaml: 1.10.2
+      yaml: 1.10.3
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.6
+      postcss: 8.5.15
       yaml: 2.9.0
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
-  postcss-safe-parser@7.0.1(postcss@8.5.6):
+  postcss-safe-parser@7.0.1(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
 
-  postcss-scss@4.0.9(postcss@8.5.6):
+  postcss-scss@4.0.9(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -4741,9 +4710,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4835,14 +4804,14 @@ snapshots:
       esm-env: 1.2.2
       svelte: 5.56.1(@typescript-eslint/types@8.56.1)
 
-  runed@0.35.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1)):
+  runed@0.35.1(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1)):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
       svelte: 5.56.1(@typescript-eslint/types@8.56.1)
     optionalDependencies:
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0))
 
   rw@1.3.3: {}
 
@@ -4974,17 +4943,17 @@ snapshots:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      postcss: 8.5.6
-      postcss-scss: 4.0.9(postcss@8.5.6)
+      postcss: 8.5.15
+      postcss-scss: 4.0.9(postcss@8.5.15)
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
     optionalDependencies:
       svelte: 5.56.1(@typescript-eslint/types@8.56.1)
 
-  svelte-toolbelt@0.10.6(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1)):
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1)):
     dependencies:
       clsx: 2.1.1
-      runed: 0.35.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
+      runed: 0.35.1(@sveltejs/kit@2.68.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.56.1))(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))(typescript@5.9.3)(vite@6.4.3(@types/node@25.3.2)(jiti@1.21.7)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.56.1))
       style-to-object: 1.0.14
       svelte: 5.56.1(@typescript-eslint/types@8.56.1)
     transitivePeerDependencies:
@@ -5044,11 +5013,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss: 8.5.15
+      postcss-import: 15.1.0(postcss@8.5.15)
+      postcss-js: 4.1.0(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.15)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -5164,7 +5133,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@2.3.2)
       picomatch: 2.3.2
-      postcss: 8.5.6
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -5273,7 +5242,7 @@ snapshots:
 
   ws@8.21.0: {}
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: 5.0.6
   cookie: 1.1.1
   devalue: 5.8.1
   esbuild: 0.28.1
   flatted: 3.4.2
   js-yaml: ^4.2.0
   lodash-es: 4.18.1
+  minimatch@3>brace-expansion: 1.1.13
+  minimatch@9>brace-expansion: 2.0.3
   picomatch: 2.3.2
   postcss: ^8.5.10
   postcss-load-config>yaml: 1.10.3
@@ -1301,6 +1302,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1321,6 +1325,12 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1380,6 +1390,9 @@ packages:
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -3816,6 +3829,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   before-after-hook@4.0.0: {}
@@ -3836,6 +3851,15 @@ snapshots:
       - '@sveltejs/kit'
 
   blake3-wasm@2.1.5: {}
+
+  brace-expansion@1.1.13:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -3893,6 +3917,8 @@ snapshots:
   commander@4.1.1: {}
 
   commander@7.2.0: {}
+
+  concat-map@0.0.1: {}
 
   cookie@1.1.1: {}
 
@@ -4572,11 +4598,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 1.1.13
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 2.0.3
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,12 @@
 overrides:
-  brace-expansion: 5.0.6
   cookie: 1.1.1
   devalue: 5.8.1
   esbuild: 0.28.1
   flatted: 3.4.2
   js-yaml: ^4.2.0
   lodash-es: 4.18.1
+  'minimatch@3>brace-expansion': 1.1.13
+  'minimatch@9>brace-expansion': 2.0.3
   picomatch: 2.3.2
   postcss: ^8.5.10
   'postcss-load-config>yaml': 1.10.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,14 @@
 overrides:
+  brace-expansion: 5.0.6
   cookie: 1.1.1
   devalue: 5.8.1
   esbuild: 0.28.1
   flatted: 3.4.2
+  js-yaml: ^4.2.0
   lodash-es: 4.18.1
   picomatch: 2.3.2
+  postcss: ^8.5.10
+  'postcss-load-config>yaml': 1.10.3
   undici: 7.28.0
   ws: 8.21.0
   zod: 4.3.6


### PR DESCRIPTION
## TIM-44 — closes moderate vulnerabilities flagged by the TIM-37 audit

`pnpm audit --audit-level=moderate` on `main` reports 20 vulnerabilities (3 low, 17 moderate) across dompurify, @sveltejs/kit, brace-expansion, js-yaml, postcss, and a transitive yaml@1.10.2. This PR applies the surgical fixes from [TIM-37] and brings the audit to **0 vulnerabilities** (verified at both `moderate` and `high` levels).

### Changes

**Direct dependency bumps (package.json)**

- `dompurify`: `3.3.2` → `^3.4.11`
- `@sveltejs/kit`: `2.57.1` → `^2.60.1`

**Transitive overrides (pnpm-workspace.yaml)**

- `js-yaml`: `^4.2.0`
- `postcss`: `^8.5.10`
- `minimatch@3>brace-expansion`: `1.1.13` — patches the vulnerable 1.1.12 line that minimatch@3 still pulls in via eslint/config-array, without affecting newer lines.
- `minimatch@9>brace-expansion`: `2.0.3` — patches the vulnerable 2.0.2 line that minimatch@9 pulls in via glob/test-exclude → @vitest/coverage-v8, without forcing 5.x on a transitive that imports via TS-style default interop.
- `postcss-load-config>yaml`: `1.10.3` — closes the transitive `yaml@1.10.2` stack-overflow GHSA. Scoped to the transitive path only, so the direct `yaml@2.9.0` dep stays on 2.x and source code (`import { parse as parseYaml } from 'yaml'`) keeps working. A global `yaml: 1.10.3` override was tried first; it broke `pnpm build` because yaml 1.x is CJS and the project is `type: "module"`.

(Original prescription in TIM-44 used a global `brace-expansion: 5.0.6`. That blew up `pnpm test:coverage` under Node 24's stricter CJS/ESM interop: `TypeError: (0 , brace_expansion_1.default) is not a function` in `minimatch@9/dist/commonjs/index.js`. The 5.x package is ESM-style CJS (`__esModule: true`, only a named `expand` export, no `default`), which minimatch@9's `import default from 'brace-expansion'` cannot consume. Switched to per-line path overrides above. CI is now green on Node 24.14.0.)

### CVE / GHSA set this PR closes

- DOMPurify (closes 11 moderate + 3 low via 3.4.11 bump):
  - GHSA-39q2-94rc-95cp — `ADD_TAGS` function bypass of `FORBID_TAGS`
  - GHSA-h7mw-gpvr-xq4m — `FORBID_TAGS` bypass via function `ADD_TAGS`
  - GHSA-crv5-9vww-q3g8 — `SAFE_FOR_TEMPLATES` bypass in `RETURN_DOM`
  - GHSA-v9jr-rg53-9pgp — Prototype Pollution to XSS via `CUSTOM_ELEMENT_HANDLING`
  - GHSA-76mc-f452-cxcm — Hook mutation of `data.allowedTags` / `data.allowedAttributes`
  - GHSA-hpcv-96wg-7vj8 — Cross-realm `IN_PLACE` sanitization
  - GHSA-r47g-fvhr-h676 — `IN_PLACE` clobbered root element XSS
  - GHSA-rp9w-3fw7-7cwq — `IN_PLACE` bypass via `<template>.content` Shadow Root
  - GHSA-cmwh-pvxp-8882 — Permanent `ALLOWED_ATTR` pollution via `setConfig()` hook
- @sveltejs/kit:
  - GHSA-hgv7-v322-mmgr — `query.batch` cross-talk
- brace-expansion:
  - GHSA-f886-m6hf-6m8v — Zero-step sequence hang (closed via 1.1.13 / 2.0.3 bumps)
  - GHSA-jxxr-4gwj-5jf2 — Large numeric range defeats `max` DoS protection (closed via 1.1.13 / 2.0.3 bumps)
- js-yaml:
  - GHSA-h67p-54hq-rp68 — Quadratic-complexity DoS in merge key handling
- postcss:
  - GHSA-qx2v-qp2m-jg93 — XSS via unescaped `</style>` in CSS Stringify output
- yaml:
  - GHSA-48c2-rrv3-qjmp — Stack overflow via deeply nested YAML collections (transitive `eslint-plugin-svelte → postcss-load-config → yaml`)

### Verification

- `pnpm install --frozen-lockfile` — passes (CI gate)
- `pnpm audit --audit-level=moderate` → `No known vulnerabilities found`
- `pnpm audit --audit-level=high` → `No known vulnerabilities found`
- `pnpm check` → 0 errors (1 pre-existing Svelte warning unrelated to this PR)
- `pnpm lint` → clean
- `pnpm test:coverage` → 148/148 passing across 9 test files; v8 coverage 88.89% lines
- `pnpm build` → succeeds with adapter-cloudflare

### Out of scope (intentionally NOT touched)

`vite` 6 → 8, ESLint 9 → 10, TypeScript 5 → 6, Marked 17 → 18, and the rest of the 1-major-behind backlog stay in the audit backlog and are not security-blocked.

Refs TIM-37

[TIM-37]: https://github.com/timoa/workflow-metrics/issues/37
